### PR TITLE
Refining/get photo versions

### DIFF
--- a/internal/handler/response/auth/auth.go
+++ b/internal/handler/response/auth/auth.go
@@ -1,7 +1,8 @@
-package response
+package auth
 
 import (
 	"github.com/gin-gonic/gin"
+	"go-photo/internal/handler/response"
 	"net/http"
 )
 
@@ -17,13 +18,13 @@ type Register struct {
 func MustGetUUID(c *gin.Context, key string) (string, bool) {
 	val, exists := c.Get(key)
 	if !exists {
-		NewErr(c, http.StatusUnauthorized, Unauthorized, nil, "Try logging in again.")
+		response.NewErr(c, http.StatusUnauthorized, response.Unauthorized, nil, "Try logging in again.")
 		return "", false
 	}
 
 	uuid, ok := val.(string)
 	if !ok {
-		NewErr(c, http.StatusInternalServerError, InternalServerError, nil, "Unexpected error occurred.")
+		response.NewErr(c, http.StatusInternalServerError, response.InternalServerError, nil, "Unexpected error occurred.")
 		return "", false
 	}
 

--- a/internal/handler/response/photo/converter.go
+++ b/internal/handler/response/photo/converter.go
@@ -1,0 +1,26 @@
+package photo
+
+import (
+	"go-photo/internal/model"
+	"time"
+)
+
+func ToPhotoVersionFromModel(photoVersion model.PhotoVersion) PhotoVersion {
+	return PhotoVersion{
+		PhotoID:     photoVersion.PhotoID,
+		VersionType: string(photoVersion.VersionType),
+		Filepath:    photoVersion.Filepath,
+		Size:        photoVersion.Size,
+		Height:      photoVersion.Height,
+		Width:       photoVersion.Width,
+		UploadedAt:  photoVersion.SavedAt.Format(time.DateTime),
+	}
+}
+
+func ToPhotoVersionsFromModel(photoVersions []model.PhotoVersion) []PhotoVersion {
+	photoVersionsResponse := make([]PhotoVersion, len(photoVersions))
+	for i, pv := range photoVersions {
+		photoVersionsResponse[i] = ToPhotoVersionFromModel(pv)
+	}
+	return photoVersionsResponse
+}

--- a/internal/handler/response/photo/converter.go
+++ b/internal/handler/response/photo/converter.go
@@ -13,7 +13,7 @@ func ToPhotoVersionFromModel(photoVersion model.PhotoVersion) PhotoVersion {
 		Size:        photoVersion.Size,
 		Height:      photoVersion.Height,
 		Width:       photoVersion.Width,
-		UploadedAt:  photoVersion.SavedAt.Format(time.DateTime),
+		SavedAt:     photoVersion.SavedAt.Format(time.DateTime),
 	}
 }
 

--- a/internal/handler/response/photo/photo.go
+++ b/internal/handler/response/photo/photo.go
@@ -27,5 +27,5 @@ type PhotoVersion struct {
 	Size        int64  `json:"size"`
 	Height      int    `json:"height"`
 	Width       int    `json:"width"`
-	UploadedAt  string `json:"uploaded_at"`
+	SavedAt     string `json:"saved_at"`
 }

--- a/internal/handler/response/photo/photo.go
+++ b/internal/handler/response/photo/photo.go
@@ -1,4 +1,4 @@
-package response
+package photo
 
 type UploadPhotoResponse struct {
 	PhotoID int `json:"photo_id"`
@@ -14,4 +14,18 @@ type UploadInfo struct {
 	PhotoID  int    `json:"photo_id,omitempty"`
 	Filename string `json:"filename"`
 	Error    error  `json:"error,omitempty"`
+}
+
+type GetPhotoVersionsResponse struct {
+	Versions []PhotoVersion `json:"versions"`
+}
+
+type PhotoVersion struct {
+	PhotoID     int    `json:"photo_id"`
+	VersionType string `json:"version_type"`
+	Filepath    string `json:"filepath"`
+	Size        int64  `json:"size"`
+	Height      int    `json:"height"`
+	Width       int    `json:"width"`
+	UploadedAt  string `json:"uploaded_at"`
 }

--- a/internal/handler/response/response.go
+++ b/internal/handler/response/response.go
@@ -24,9 +24,9 @@ const (
 	AuthHeaderInvalid    ErrMessage = "auth_header_invalid"
 	AuthTokenInvalid     ErrMessage = "auth_token_invalid"
 	Unauthorized         ErrMessage = "unauthorized"
+	Forbidden            ErrMessage = "access_denied"
 
-	PhotoNotFound         ErrMessage = "photo_not_found"
-	PhotoVersionsNotFound ErrMessage = "photo_versions_not_found"
+	PhotoNotFound ErrMessage = "photo_not_found"
 )
 
 type Error struct {

--- a/internal/handler/response/response.go
+++ b/internal/handler/response/response.go
@@ -24,6 +24,9 @@ const (
 	AuthHeaderInvalid    ErrMessage = "auth_header_invalid"
 	AuthTokenInvalid     ErrMessage = "auth_token_invalid"
 	Unauthorized         ErrMessage = "unauthorized"
+
+	PhotoNotFound         ErrMessage = "photo_not_found"
+	PhotoVersionsNotFound ErrMessage = "photo_versions_not_found"
 )
 
 type Error struct {

--- a/internal/handler/v1/auth/auth.go
+++ b/internal/handler/v1/auth/auth.go
@@ -17,7 +17,7 @@ import (
 // @Accept json
 // @Produce json
 // @Param input body request.AuthLogin true "Login credentials"
-// @Success 200 {object} response.Login
+// @Success 200 {object} auth.Login
 // @Failure 400 {object} response.Error "Invalid request body format."
 // @Failure 401 {object} response.Error "Email or password is incorrect."
 // @Failure 500 {object} response.Error "Unexpected error occurred."
@@ -48,7 +48,7 @@ func (h *handler) login(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param input body request.AuthRegister true "Registration credentials"
-// @Success 200 {object} response.Register
+// @Success 200 {object} auth.Register
 // @Failure 400 {object} response.Error "Invalid request body format."
 // @Failure 409 {object} response.Error "User with this email already exists."
 // @Failure 500 {object} response.Error "Unexpected error occurred."

--- a/internal/handler/v1/auth/auth.go
+++ b/internal/handler/v1/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go-photo/internal/handler/request"
 	"go-photo/internal/handler/response"
+	"go-photo/internal/handler/response/auth"
 	serviceErr "go-photo/internal/service/error"
 	serviceUserModel "go-photo/internal/service/user/model"
 	"net/http"
@@ -38,7 +39,7 @@ func (h *handler) login(c *gin.Context) {
 		return
 	}
 
-	response.NewOk(c, response.Login{Token: token})
+	response.NewOk(c, auth.Login{Token: token})
 }
 
 // @Summary Register user
@@ -73,5 +74,5 @@ func (h *handler) register(c *gin.Context) {
 		return
 	}
 
-	response.NewOk(c, response.Register{UserUUID: info.UserUUID, Token: info.Token})
+	response.NewOk(c, auth.Register{UserUUID: info.UserUUID, Token: info.Token})
 }

--- a/internal/handler/v1/auth/auth_test.go
+++ b/internal/handler/v1/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go-photo/internal/handler/response"
+	"go-photo/internal/handler/response/auth"
 	serviceErr "go-photo/internal/service/error"
 	mock_service "go-photo/internal/service/mock"
 	serviceUserModel "go-photo/internal/service/user/model"
@@ -35,7 +36,7 @@ func TestHandler_login(t *testing.T) {
 				s.EXPECT().Login(gomock.Any(), email, password).Return("accessToken", nil).Times(1)
 			},
 			expectedStatusCode: 200,
-			expectedResponse: response.Login{
+			expectedResponse: auth.Login{
 				Token: "accessToken",
 			},
 		},
@@ -153,7 +154,7 @@ func TestHandler_register(t *testing.T) {
 				}, nil).Times(1)
 			},
 			expectedStatusCode: 200,
-			expectedResponse: response.Register{
+			expectedResponse: auth.Register{
 				UserUUID: "user-id",
 				Token:    "jwt-token",
 			},

--- a/internal/handler/v1/photos/handler.go
+++ b/internal/handler/v1/photos/handler.go
@@ -26,6 +26,6 @@ func (h *handler) RegisterRoutes(router *gin.RouterGroup) {
 	{
 		photosGroup.POST("/", h.uploadPhoto)
 		photosGroup.POST("/batch", h.uploadBatchPhotos)
-		photosGroup.GET("/:id", h.getPhotoVersions)
+		photosGroup.GET("/:id/versions", h.getPhotoVersions)
 	}
 }

--- a/internal/handler/v1/photos/photo.go
+++ b/internal/handler/v1/photos/photo.go
@@ -32,7 +32,7 @@ const (
 // @Produce json
 // @Security JWTAuth
 // @Param photo_file formData file true "Photo file"
-// @Success 200 {object} response.UploadPhotoResponse
+// @Success 200 {object} photo.UploadPhotoResponse
 // @Failure 400 {object} response.Error "Bad Request."
 // @Failure 401 {object} response.Error "Unauthorized."
 // @Failure 500 {object} response.Error "Unexpected error occurred."
@@ -73,8 +73,8 @@ func (h *handler) uploadPhoto(c *gin.Context) {
 // @Produce json
 // @Security JWTAuth
 // @Param batch_photo_files formData file true "Batch photo files"
-// @Success 200 {object} response.UploadBatchPhotosResponse
-// @Failure 206 {object} response.UploadBatchPhotosResponse
+// @Success 200 {object} photo.UploadBatchPhotosResponse
+// @Failure 206 {object} photo.UploadBatchPhotosResponse
 // @Failure 400 {object} response.Error "Bad Request."
 // @Failure 401 {object} response.Error "Unauthorized."
 // @Failure 500 {object} response.Error "Unexpected error occurred."

--- a/internal/handler/v1/photos/photo.go
+++ b/internal/handler/v1/photos/photo.go
@@ -7,6 +7,8 @@ import (
 	"go-photo/internal/config"
 	"go-photo/internal/handler/middleware"
 	"go-photo/internal/handler/response"
+	"go-photo/internal/handler/response/auth"
+	"go-photo/internal/handler/response/photo"
 	serviceErr "go-photo/internal/service/error"
 	"go-photo/internal/service/photo/model"
 	"go-photo/internal/utils"
@@ -39,7 +41,7 @@ func (h *handler) uploadPhoto(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, config.DefaultContextTimeout)
 	defer cancel()
 
-	uuid, ok := response.MustGetUUID(c, middleware.UserUUIDCtx)
+	uuid, ok := auth.MustGetUUID(c, middleware.UserUUIDCtx)
 	if !ok {
 		return
 	}
@@ -61,7 +63,7 @@ func (h *handler) uploadPhoto(c *gin.Context) {
 		return
 	}
 
-	response.NewOk(c, response.UploadPhotoResponse{PhotoID: photoID})
+	response.NewOk(c, photo.UploadPhotoResponse{PhotoID: photoID})
 }
 
 // @Summary Upload batch photos
@@ -83,7 +85,7 @@ func (h *handler) uploadBatchPhotos(c *gin.Context) {
 
 	respStatus := http.StatusOK
 
-	uuid, ok := response.MustGetUUID(c, middleware.UserUUIDCtx)
+	uuid, ok := auth.MustGetUUID(c, middleware.UserUUIDCtx)
 	if !ok {
 		return
 	}
@@ -114,10 +116,10 @@ func (h *handler) uploadBatchPhotos(c *gin.Context) {
 		return
 	}
 
-	body := response.UploadBatchPhotosResponse{
+	body := photo.UploadBatchPhotosResponse{
 		TotalCount:   uploads.Total(),
 		SuccessCount: uploads.SuccessCount(),
-		UploadInfos:  append(make([]response.UploadInfo, 0), model.ToUploadsInfoFromService(uploads.Get())...),
+		UploadInfos:  append(make([]photo.UploadInfo, 0), model.ToUploadsInfoFromService(uploads.Get())...),
 	}
 
 	c.JSON(respStatus, body)
@@ -136,16 +138,16 @@ func (h *handler) getPhotoVersions(c *gin.Context) {
 		return
 	}
 
-	version, err := h.photoService.GetPhotoVersions(ctx, id)
-	if err != nil {
-		response.NewErr(c, http.StatusInternalServerError, response.InternalServerError, err, "Failed to get photo versions.")
+	versions, err := h.photoService.GetPhotoVersions(ctx, id)
+	if errors.Is(err, serviceErr.PhotoNotFoundError) {
+		response.NewErr(c, http.StatusNotFound, response.PhotoNotFound, err, "Photo not found.")
 		return
 	}
 	if response.HandleError(c, err) {
 		return
 	}
 
-	c.JSON(200, gin.H{
-		"versions": version,
+	response.NewOk(c, photo.GetPhotoVersionsResponse{
+		Versions: photo.ToPhotoVersionsFromModel(versions),
 	})
 }

--- a/internal/handler/v1/photos/photo_test.go
+++ b/internal/handler/v1/photos/photo_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go-photo/internal/handler/middleware"
 	"go-photo/internal/handler/response"
+	"go-photo/internal/handler/response/photo"
 	serviceErr "go-photo/internal/service/error"
 	mockservice "go-photo/internal/service/mock"
 	serviceModel "go-photo/internal/service/photo/model"
@@ -185,7 +186,7 @@ func TestHandler_uploadBatchPhotos(t *testing.T) {
 					Times(1)
 			},
 			expectedStatusCode: 200,
-			expectedResponse: response.UploadBatchPhotosResponse{
+			expectedResponse: photo.UploadBatchPhotosResponse{
 				TotalCount:   3,
 				SuccessCount: 3,
 				UploadInfos:  serviceModel.ToUploadsInfoFromService(defaultUploads.Get()),
@@ -220,7 +221,7 @@ func TestHandler_uploadBatchPhotos(t *testing.T) {
 					Times(1)
 			},
 			expectedStatusCode: 206,
-			expectedResponse: response.UploadBatchPhotosResponse{
+			expectedResponse: photo.UploadBatchPhotosResponse{
 				TotalCount:   3,
 				SuccessCount: 2,
 				UploadInfos:  serviceModel.ToUploadsInfoFromService(createPartialUploads().Get()),
@@ -240,7 +241,7 @@ func TestHandler_uploadBatchPhotos(t *testing.T) {
 					Times(1)
 			},
 			expectedStatusCode: 400,
-			expectedResponse: response.UploadBatchPhotosResponse{
+			expectedResponse: photo.UploadBatchPhotosResponse{
 				TotalCount:   2,
 				SuccessCount: 0,
 				UploadInfos:  serviceModel.ToUploadsInfoFromService(createFailedUploads().Get()),

--- a/internal/model/photo.go
+++ b/internal/model/photo.go
@@ -24,4 +24,7 @@ type PhotoVersion struct {
 	VersionType PhotoVersionType
 	Filepath    string
 	Size        int64
+	Height      int
+	Width       int
+	SavedAt     time.Time
 }

--- a/internal/repository/error/errors.go
+++ b/internal/repository/error/errors.go
@@ -8,8 +8,6 @@ import (
 var (
 	NotFoundError = errors.New("not found")
 
-	PhotoNotFound = fmt.Errorf("photo %w", NotFoundError)
-
 	BeginTxError  = errors.New("failed to begin transaction")
 	CommitTxError = errors.New("failed to commit transaction")
 

--- a/internal/repository/error/errors.go
+++ b/internal/repository/error/errors.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	NotFoundError = errors.New("not found")
+
 	PhotoNotFound = fmt.Errorf("photo %w", NotFoundError)
 
 	BeginTxError  = errors.New("failed to begin transaction")

--- a/internal/repository/photo/converter/photo.go
+++ b/internal/repository/photo/converter/photo.go
@@ -32,5 +32,8 @@ func ToPhotoVersionFromRepo(version repoModel.PhotoVersion) model.PhotoVersion {
 		VersionType: model.PhotoVersionType(version.VersionType.String),
 		Filepath:    version.Filepath,
 		Size:        version.Size,
+		Height:      version.Height,
+		Width:       version.Width,
+		SavedAt:     version.SavedAt.Time,
 	}
 }

--- a/internal/repository/photo/repository.go
+++ b/internal/repository/photo/repository.go
@@ -91,7 +91,7 @@ func (r *repository) GetPhotoByID(ctx context.Context, photoID int) (*repoModel.
 	err := r.db.GetContext(ctx, &photo, query, photoID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, repoErr.PhotoNotFound
+			return nil, repoErr.NotFoundError
 		}
 		return nil, err
 	}
@@ -103,13 +103,16 @@ func (r *repository) GetPhotoVersions(ctx context.Context, photoID int) ([]repoM
 	var versions []repoModel.PhotoVersion
 
 	query := `
-		SELECT id, photo_id, version_type, filepath, size , height, width, saved_at
+		SELECT id, photo_id, version_type, filepath, size, height, width, saved_at
 		FROM photo_versions 
 		WHERE photo_id = $1
 		ORDER BY size`
 
 	err := r.db.SelectContext(ctx, &versions, query, photoID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, repoErr.NotFoundError
+		}
 		return nil, err
 	}
 

--- a/internal/repository/photo/repository.go
+++ b/internal/repository/photo/repository.go
@@ -111,7 +111,7 @@ func (r *repository) GetPhotoVersions(ctx context.Context, photoID int) ([]repoM
 	}
 
 	query := `
-		SELECT id, photo_id, version_type, filepath, size 
+		SELECT id, photo_id, version_type, filepath, size , height, width, saved_at
 		FROM photo_versions 
 		WHERE photo_id = $1
 		ORDER BY size`

--- a/internal/repository/photo/repository.go
+++ b/internal/repository/photo/repository.go
@@ -102,21 +102,13 @@ func (r *repository) GetPhotoByID(ctx context.Context, photoID int) (*repoModel.
 func (r *repository) GetPhotoVersions(ctx context.Context, photoID int) ([]repoModel.PhotoVersion, error) {
 	var versions []repoModel.PhotoVersion
 
-	_, err := r.GetPhotoByID(ctx, photoID)
-	if errors.Is(err, repoErr.PhotoNotFound) {
-		return nil, repoErr.PhotoNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to get photo by id: %w", err)
-	}
-
 	query := `
 		SELECT id, photo_id, version_type, filepath, size , height, width, saved_at
 		FROM photo_versions 
 		WHERE photo_id = $1
 		ORDER BY size`
 
-	err = r.db.Select(&versions, query, photoID)
+	err := r.db.SelectContext(ctx, &versions, query, photoID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -13,10 +13,9 @@ type PhotoRepository interface {
 	CreateOriginalPhoto(ctx context.Context, photo *repoModel.CreateOriginalPhotoParams) (int, error)
 
 	// GetPhotoByID возвращает фото по его ID.
-	// Если фото не найдено, возвращает ошибку PhotoNotFound
+	// Если фото не найдено, возвращает ошибку PhotoNotFound.
 	GetPhotoByID(ctx context.Context, photoID int) (*repoModel.Photo, error)
 
-	// GetPhotoVersions возвращает все версии фото по его ID отсортированные по размеру по возрастанию.
-	//
+	// GetPhotoVersions возвращает все версии фото по его ID.
 	GetPhotoVersions(ctx context.Context, photoID int) ([]repoModel.PhotoVersion, error)
 }

--- a/internal/service/error/errors.go
+++ b/internal/service/error/errors.go
@@ -24,4 +24,6 @@ var (
 	UserNotFoundError         = errors.New("user not found")
 	UserAlreadyExistsError    = errors.New("user already exists")
 	UserUnauthtenticatedError = errors.New("user unauthenticated")
+
+	PhotoNotFoundError = errors.New("photo not found")
 )

--- a/internal/service/error/errors.go
+++ b/internal/service/error/errors.go
@@ -18,6 +18,8 @@ var (
 	ServiceError = errors.New("service error")
 	DbError      = errors.New("db error")
 
+	AccessDeniedError = errors.New("access denied")
+
 	ParticalSuccessError = errors.New("partical success")
 	AllFailedError       = errors.New("all failed")
 

--- a/internal/service/photo/get_photo_versions.go
+++ b/internal/service/photo/get_photo_versions.go
@@ -11,7 +11,7 @@ import (
 
 func (s *service) GetPhotoVersions(ctx context.Context, userUUID string, photoID int) ([]model.PhotoVersion, error) {
 	candidate, err := s.photoRepository.GetPhotoByID(ctx, photoID)
-	if errors.Is(err, repoErr.PhotoNotFound) {
+	if errors.Is(err, repoErr.NotFoundError) {
 		return nil, serviceErr.PhotoNotFoundError
 	}
 	if err != nil {
@@ -23,7 +23,7 @@ func (s *service) GetPhotoVersions(ctx context.Context, userUUID string, photoID
 	}
 
 	repoVersions, err := s.photoRepository.GetPhotoVersions(ctx, photoID)
-	if errors.Is(err, repoErr.PhotoNotFound) {
+	if errors.Is(err, repoErr.NotFoundError) {
 		return nil, serviceErr.PhotoNotFoundError
 	}
 	if err != nil {

--- a/internal/service/photo/get_photo_versions.go
+++ b/internal/service/photo/get_photo_versions.go
@@ -2,13 +2,18 @@ package photo
 
 import (
 	"context"
+	"errors"
 	"go-photo/internal/model"
+	repoErr "go-photo/internal/repository/error"
 	"go-photo/internal/repository/photo/converter"
+	serviceErr "go-photo/internal/service/error"
 )
 
 func (s *service) GetPhotoVersions(ctx context.Context, id int) ([]model.PhotoVersion, error) {
 	repoVersions, err := s.photoRepository.GetPhotoVersions(ctx, id)
-	// TODO: err handling
+	if errors.Is(err, repoErr.PhotoNotFound) {
+		return nil, serviceErr.PhotoNotFoundError
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/photo/get_photo_versions.go
+++ b/internal/service/photo/get_photo_versions.go
@@ -9,8 +9,20 @@ import (
 	serviceErr "go-photo/internal/service/error"
 )
 
-func (s *service) GetPhotoVersions(ctx context.Context, id int) ([]model.PhotoVersion, error) {
-	repoVersions, err := s.photoRepository.GetPhotoVersions(ctx, id)
+func (s *service) GetPhotoVersions(ctx context.Context, userUUID string, photoID int) ([]model.PhotoVersion, error) {
+	candidate, err := s.photoRepository.GetPhotoByID(ctx, photoID)
+	if errors.Is(err, repoErr.PhotoNotFound) {
+		return nil, serviceErr.PhotoNotFoundError
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if candidate.UserUUID != userUUID {
+		return nil, serviceErr.AccessDeniedError
+	}
+
+	repoVersions, err := s.photoRepository.GetPhotoVersions(ctx, photoID)
 	if errors.Is(err, repoErr.PhotoNotFound) {
 		return nil, serviceErr.PhotoNotFoundError
 	}

--- a/internal/service/photo/model/photo.go
+++ b/internal/service/photo/model/photo.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"go-photo/internal/handler/response"
+	"go-photo/internal/handler/response/photo"
 	"sync"
 	"time"
 )
@@ -79,10 +79,10 @@ func (il *UploadInfoList) IsSomeError() bool {
 	return errCount > 0 && errCount < il.total
 }
 
-func ToUploadsInfoFromService(uploads []UploadInfo) []response.UploadInfo {
-	uploadsInfo := make([]response.UploadInfo, 0, len(uploads))
+func ToUploadsInfoFromService(uploads []UploadInfo) []photo.UploadInfo {
+	uploadsInfo := make([]photo.UploadInfo, 0, len(uploads))
 	for _, upload := range uploads {
-		uploadsInfo = append(uploadsInfo, response.UploadInfo{
+		uploadsInfo = append(uploadsInfo, photo.UploadInfo{
 			PhotoID:  upload.PhotoID,
 			Filename: upload.Filename,
 			Error:    upload.Error,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -28,8 +28,13 @@ type PhotoService interface {
 	// UploadPhoto загружает фотографию и сохраняет ее в файловой системе и базе данных.
 	// Возвращает ID загруженной фотографии.
 	UploadPhoto(ctx context.Context, userUUID string, photoFile *multipart.FileHeader) (int, error)
+
 	// UploadBatchPhotos загружает несколько фотографий конкурентно. Возвращает список информации о загруженных фотографиях.
 	// Если возникла ошибка во время загрузки фотографии, то прикрепляет информацию об ошибке.
 	UploadBatchPhotos(ctx context.Context, userUUID string, photoFiles []*multipart.FileHeader) (*servicePhotoModel.UploadInfoList, error)
-	GetPhotoVersions(ctx context.Context, photoID int) ([]model.PhotoVersion, error)
+
+	// GetPhotoVersions получает все версии фотографии по ее ID.
+	// Осуществляет проверку прав доступа к фотографии.
+	// Возвращает список версий фотографии.
+	GetPhotoVersions(ctx context.Context, userUUID string, photoID int) ([]model.PhotoVersion, error)
 }


### PR DESCRIPTION
Этот запрос включает в себя несколько изменений в проекте `go-photo`, сфокусированных на реструктуризации обработки ответов и добавлении новых функций, связанных с версиями фотографий. Наиболее важные изменения включают переименование и рефакторинг файлов для лучшей организации, добавление новых типов ответов и функций преобразования для версий фотографий, а также обновление различных обработчиков и тестов для отражения этих изменений.

### Рефакторинг и переименование файлов:

* `internal/handler/response/auth.go` был переименован в `internal/handler/response/auth/auth.go` и обновлен для использования пакета `auth`.
* `internal/handler/response/photo.go` был переименован в `internal/handler/response/photo/photo.go` и обновлен для использования пакета `photo`.

### Добавление новых типов ответов и функций преобразования:

* Добавлены типы `GetPhotoVersionsResponse` и `PhotoVersion` в `internal/handler/response/photo/photo.go`.
* Реализованы функции преобразования `ToPhotoVersionFromModel` и `ToPhotoVersionsFromModel` в `internal/handler/response/photo/converter.go` для преобразования данных модели в данные ответа.

### Обновления обработчика:

* Обновлен обработчик `getPhotoVersions` в `internal/handler/v1/photos/photo.go` для использования новых типов ответов и функций преобразования. Добавлена обработка ошибок для сценариев «Фотография не найдена» и «Доступ запрещен». [[1]](diffhunk://#diff-525c00510ad38f194883e55a3d3709d66f9baeabb6e65fca85a4c7a95a5711eaL86-R90) [[2]](diffhunk://#diff-525c00510ad38f194883e55a3d3709d66f9baeabb6e65fca85a4c7a95a5711eaL117-R173)
* Изменен конечный пункт

